### PR TITLE
Change from alpine+python+s3cmd to node-alpine+s3-cli drops image siz…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,10 @@
-FROM alpine:latest
+FROM mhart/alpine-node:latest
 
-RUN apk add --update-cache python py-pip ca-certificates tzdata \
-    && pip install s3cmd \
-    && rm -fR /etc/periodic \
-    && rm -rf /var/cache/apk/*
+# Could remove bash to trim .5 MB
+RUN apk add --update bash && rm -rf /var/cache/apk/*
+
+# Approx 2MB
+RUN npm install -g s3-cli
 
 COPY backup /usr/local/bin/
 RUN chmod +x /usr/local/bin/backup
@@ -12,4 +13,4 @@ COPY s3cfg /root/.s3cfg
 COPY entrypoint.sh /sbin/entrypoint.sh
 RUN chmod +x /sbin/entrypoint.sh
 
-CMD /sbin/entrypoint.sh
+CMD /sbin/entrypoint.sh 

--- a/backup
+++ b/backup
@@ -11,6 +11,21 @@ BACKUP_AWS_KEY=${BACKUP_AWS_KEY:-}
 BACKUP_AWS_SECRET=${BACKUP_AWS_SECRET:-}
 BACKUP_AWS_S3_PATH=${BACKUP_AWS_S3_PATH:-}
 
+if [[ ! ${BACKUP_AWS_KEY} ]]; then
+	echo BACKUP_AWS_KEY is required
+	exit 1
+fi
+
+if [[ ! ${BACKUP_AWS_SECRET} ]]; then
+	echo BACKUP_AWS_SECRET is required
+	exit 1
+fi
+
+if [[ ! ${BACKUP_AWS_S3_PATH} ]]; then
+	echo BACKUP_AWS_S3_PATH is required
+	exit 1
+fi
+
 # prepare unique name with date like 2015-09-04T03-40-34UTC
 backup_time="$(date -Iseconds | sed 's/:/-/g')"
 backup_src=${BACKUP_DEST_FOLDER}/src.${backup_time}
@@ -24,10 +39,13 @@ tar -cvz \
 # remove src file
 rm "${backup_src}"
 # upload to amazon s3
+
+echo "[default]" > ~/.s3cfg
+echo "access_key = ${BACKUP_AWS_KEY}" >> ~/.s3cfg
+echo "secret_key = ${BACKUP_AWS_SECRET}" >> ~/.s3cfg
+ 
 if [[ ${BACKUP_AWS_S3_PATH} ]]; then
-    s3cmd \
-        --access_key="${BACKUP_AWS_KEY:?'BACKUP_AWS_KEY is required'}" \
-        --secret_key="${BACKUP_AWS_SECRET:?'BACKUP_AWS_SECRET is required'}" \
+    s3-cli \
         put "${backup_archive}" \
         "${BACKUP_AWS_S3_PATH}"
 fi


### PR DESCRIPTION
I'm looking at modifying your image to handle some custom backups with a node script.  When I changed out your alpine image with node-alpine and used the node s3 cli client instead of s3cmd the image size dropped by about 12MB.  You could cut another .5 by removing bash from the Dockerfile.

REPOSITORY                  TAG                 IMAGE ID            CREATED             VIRTUAL SIZE
cmann50/docker-backup       latest              46a643eae09e        15 minutes ago      40.94 MB
outcoldman/backup           latest              a93206a4f10f        4 days ago          53.43 MB

Functionality is exactly the same.  I tested and it's working fine with my amazon bucket.  Feel free to incorporate it if you like.
