### PR TITLE
Cron: Use default log level

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -14,4 +14,4 @@ BACKUP_CRON_SCHEDULE=${BACKUP_CRON_SCHEDULE:-"0 2 * * *"}
 echo "${BACKUP_CRON_SCHEDULE} /usr/local/bin/backup" > /etc/crontabs/root
 
 # Starting cron
-crond -f -d 0
+crond -f


### PR DESCRIPTION
Log level 0 pollutes the log by adding some lines every single minute. IMHO the default log level (which seems to be 8) should be ok.